### PR TITLE
`remove` unused packages

### DIFF
--- a/MusicPlayer.iml
+++ b/MusicPlayer.iml
@@ -9,9 +9,6 @@
     <orderEntry type="inheritedJdk" />
     <orderEntry type="sourceFolder" forTests="false" />
     <orderEntry type="library" name="lib" level="project" />
-    <orderEntry type="library" name="JLibXX_pretest" level="project" />
     <orderEntry type="library" name="jl1.0.1" level="project" />
-    <orderEntry type="library" name="javafx-sdk-17.01" level="application" />
-    <orderEntry type="library" name="KotlinJavaRuntime" level="project" />
   </component>
 </module>


### PR DESCRIPTION
Some of these libraries are now unused or are not found in the `/lib` dir.